### PR TITLE
Update `publish-conda` workflow.

### DIFF
--- a/.github/workflows/publish-conda.yaml
+++ b/.github/workflows/publish-conda.yaml
@@ -2,9 +2,9 @@ name: publish/conda
 run-name: ${{
     format(
       '[{0}] publish/conda{1}',
-      (github.event_name == 'pull_request' && format('pr/{0}', github.event.number)) ||
-      (github.event_name == 'push' && github.ref_name) ||
-      (github.event_name == 'release' && github.event.release.tag_name) ||
+      (github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_branch) ||
+      (github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch) ||
+      (github.event.workflow_run.event == 'release' && github.event.workflow_run.head_branch) ||
       github.event_name,
       (github.event.action == 'requested' && ' (requested)') || ''
     )


### PR DESCRIPTION
Improve workflow naming to help identify runs.